### PR TITLE
react/socket upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "tightenco/collect": "~5.0",
         "opis/closure": "^2.3 || ^3.0",
         "mpociot/pipeline": "^1.0",
-        "react/socket": "~0.4",
+        "react/socket": "~1.0",
         "spatie/macroable": "^1.0",
         "psr/container": "^1.0"
     },


### PR DESCRIPTION
People trying to install laravel-websockets are experiencing issues with conflicting dependency versions: https://github.com/beyondcode/laravel-websockets/issues/35
react/socket 1.x.x is fully compatible with the v0.8.12 release used currently in botman. I assume it's safe to upgrade.